### PR TITLE
Display name of referrer

### DIFF
--- a/models/referral.rb
+++ b/models/referral.rb
@@ -28,16 +28,18 @@ class Referral
         Referral.new(
           id: row[1].tr(" ", "_").downcase,
           company: row[1],
-          code: row[2]
+          code: row[2],
+          name: row[0]
         )
       }
   end
 
-  attr_reader :id, :company, :code
+  attr_reader :id, :company, :code, :name
 
-  def initialize(id:, company:, code:)
+  def initialize(id:, company:, code:, name:)
     @id = id
     @company = company
     @code = code
+    @name = name
   end
 end

--- a/models/referral_spec.rb
+++ b/models/referral_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Referral do
     Referral.new(
       id: "fake_id",
       company: "Fake Company",
-      code: "12356789"
+      code: "12356789",
+      name: "Alice"
     )
   }
 
@@ -58,6 +59,12 @@ RSpec.describe Referral do
   describe "#code" do
     it "returns the code" do
       expect(subject.code).to eql("12356789")
+    end
+  end
+
+  describe "#name" do
+    it "returns the name" do
+      expect(subject.name).to eql("Alice")
     end
   end
 end

--- a/server.rb
+++ b/server.rb
@@ -14,8 +14,9 @@ get "/code", provides: "html" do
   relevant_referrals = referrals_by_company_id(id: params["company_id"])
   random_referral = relevant_referrals.sample
   code = random_referral.code
+  name = random_referral.name
 
-  erb :referral_code, layout: :layout, locals: {code: code}
+  erb :referral_code, layout: :layout, locals: {code: code, name: name}
 end
 
 def referrals

--- a/views/referral_code.erb
+++ b/views/referral_code.erb
@@ -1,3 +1,5 @@
 <h2>Your referral code</h2>
 
 <%= code %>
+
+<p>Referral code from <%= name %></p>


### PR DESCRIPTION
The name of the referrer is now displayed with the referral code

<img width="693" alt="Screenshot 2022-08-03 at 16 57 19" src="https://user-images.githubusercontent.com/59832893/182654986-01d062e9-df89-465c-8ae8-cc54d14a98da.png">

